### PR TITLE
fix(bin/postinstall): missing postinstall file

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "src",
     "lib",
     "android",
+    "bin",
     "!lib/typescript/example",
     "!**/__tests__",
     "!**/__fixtures__",


### PR DESCRIPTION
Missing bin directory when you install package from npm